### PR TITLE
Terminate args array properly

### DIFF
--- a/src/args.c
+++ b/src/args.c
@@ -4,15 +4,16 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <time.h>
+#include "args.h"
 
-void parse_args(int argc, char **argv)
-{
+void parse_args(int argc, char **argv) {
     srand(time(NULL));
 
     while (1) {
         struct option long_options[] = {
             {"help", no_argument,       NULL, 'h'},
             {"seed", required_argument, NULL, 's'},
+            {0, 0, 0, 0}
         };
         int c = getopt_long(argc, argv, "hs:", long_options, NULL);
         unsigned long seed;


### PR DESCRIPTION
There was a small error in my command-line options PR (#77). According to the [`getopt` man page](http://man7.org/linux/man-pages/man3/getopt.3.html):
> The last element of the array has to be filled with zeros.

So I just added a zeroed-out element to the end of `long_options` in `args.c`.