### PR TITLE
Speed stat

### DIFF
--- a/src/core/main.c
+++ b/src/core/main.c
@@ -38,7 +38,6 @@ int main(int argc, char **argv)
     int ch;
     int moved;
     int numRows;
-    int subtick;
     struct winsize w;
     item_t *item;
     player_t *player;
@@ -92,7 +91,6 @@ int main(int argc, char **argv)
     item_give();
     add_action(flavortext_from_floor());
     map_los(player->y, player->x, 8, '.' | A_BOLD | COLORS_WHITE);
-    subtick = 0;
 
     while (player->current_hp > 0) {
         moved = 1;
@@ -114,7 +112,7 @@ int main(int argc, char **argv)
         xn = player->x;
         yn = player->y;
         ch = ERR;
-        if (subtick < player->speed && (ch = getch(), ch != ERR)) {
+        if (ch = getch(), ch != ERR) {
             if (rand() % player->luck) {
                 switch (ch) {
                 case 0x102:
@@ -263,12 +261,11 @@ int main(int argc, char **argv)
         } else {
             add_action("You can't walk through walls.");
         }
-        enemy_turn_driver(my_wins[0], player->y, player->x, subtick);
+        enemy_turn_driver(my_wins[0], player->y, player->x);
         map_los(player->y, player->x, 8, '.' | A_BOLD | COLORS_WHITE);
         key_checker(my_wins[2], player->y, player->x);
         if (moved) {
             tick++;
-            subtick = (subtick + 1) % 10;
         }
     }
     print_stats(player, my_wins[2], floor_tick_get());

--- a/src/core/main.c
+++ b/src/core/main.c
@@ -36,7 +36,9 @@ int main(int argc, char **argv)
     int xn;
     int yn;
     int ch;
+    int moved;
     int numRows;
+    int subtick;
     struct winsize w;
     item_t *item;
     player_t *player;
@@ -90,8 +92,10 @@ int main(int argc, char **argv)
     item_give();
     add_action(flavortext_from_floor());
     map_los(player->y, player->x, 8, '.' | A_BOLD | COLORS_WHITE);
+    subtick = 0;
+
     while (player->current_hp > 0) {
-        tick++;
+        moved = 1;
         refresh();
         werase(my_wins[2]);
         print_stats(player, my_wins[2], floor_tick_get());
@@ -110,7 +114,7 @@ int main(int argc, char **argv)
         xn = player->x;
         yn = player->y;
         ch = ERR;
-        if (ch = getch(), ch != ERR) {
+        if (subtick < player->speed && (ch = getch(), ch != ERR)) {
             if (rand() % player->luck) {
                 switch (ch) {
                 case 0x102:
@@ -209,6 +213,8 @@ int main(int argc, char **argv)
                     break;
                 default:
                     add_action("Invalid button. Press '?' for the manual");
+                    moved = 0;
+                    continue;
                     break;
                 }
             } else {
@@ -257,9 +263,13 @@ int main(int argc, char **argv)
         } else {
             add_action("You can't walk through walls.");
         }
-        enemy_turn_driver(my_wins[0], player->y, player->x);
+        enemy_turn_driver(my_wins[0], player->y, player->x, subtick);
         map_los(player->y, player->x, 8, '.' | A_BOLD | COLORS_WHITE);
         key_checker(my_wins[2], player->y, player->x);
+        if (moved) {
+            tick++;
+            subtick = (subtick + 1) % 10;
+        }
     }
     print_stats(player, my_wins[2], floor_tick_get());
     gui_prompt("You have died! Press space to exit.", " ");

--- a/src/logic/enemy.c
+++ b/src/logic/enemy.c
@@ -3,6 +3,7 @@
 #include "list.h"
 #include "map.h"
 #include "gui.h"
+#include "main.h"
 #include "stdlib.h"
 #include "player.h"
 
@@ -14,8 +15,8 @@ void enemy_set(list_t * list)
 }
 
 enemy_t *enemy_add(list_t * floor_enemy_list, int type, int pic, int hp,
-                   int y, int x, int sight_range, int strength, int xp,
-                   char *name)
+                   int y, int x, int sight_range, int strength, 
+                   int speed, int xp, char *name)
 {
     enemy_t *e;
     if (!floor_enemy_list) {
@@ -33,6 +34,7 @@ enemy_t *enemy_add(list_t * floor_enemy_list, int type, int pic, int hp,
     e->x = x;
     e->sight_range = sight_range;
     e->strength = strength;
+    e->speed = speed;
     e->xp = xp;
     e->name = name;
     e->node = list_add_tail(floor_enemy_list, e);
@@ -90,7 +92,8 @@ void enemy_hurt(enemy_t * e, int d)
                     en = get_rulebook()[enemy_index_fake_hag()];
                     enemy_add(0, enemy_index_fake_hag(), en.pic,
                               en.base_hp, ny, nx, en.base_sight_range,
-                              en.base_strength, en.base_exp, "Fake");
+                              en.base_strength, en.base_speed,
+                              en.base_exp, "Fake");
                     nx += (rand() % 2 * 2 - 1) * ((rand() % 4) + 5);
                     ny += (rand() % 2 * 2 - 1) * ((rand() % 4) + 5);
                     map_line(e->y, e->x, ny, nx);
@@ -156,12 +159,16 @@ void enemy_clear()
     enemy_list->tail = 0;
 }
 
-void enemy_turn_driver(WINDOW * win, int y, int x)
+void enemy_turn_driver(WINDOW * win, int y, int x, int subtick)
 {
-    node_t *e = enemy_list->head;
-    while (e) {
-        enemy_take_turn(e->data, win, y, x);
-        e = e->next;
+    enemy_t *e;
+    node_t *l = enemy_list->head;
+    while (l) {
+        e = (enemy_t*)l->data;
+        if (e->speed > subtick) {
+            enemy_take_turn(e, win, y, x);
+        }
+        l = l->next;
     }
 }
 

--- a/src/logic/enemy.c
+++ b/src/logic/enemy.c
@@ -15,7 +15,7 @@ void enemy_set(list_t * list)
 }
 
 enemy_t *enemy_add(list_t * floor_enemy_list, int type, int pic, int hp,
-                   int y, int x, int sight_range, int strength, 
+                   int y, int x, int sight_range, int strength,
                    int speed, int xp, char *name)
 {
     enemy_t *e;

--- a/src/logic/enemy.c
+++ b/src/logic/enemy.c
@@ -35,6 +35,7 @@ enemy_t *enemy_add(list_t * floor_enemy_list, int type, int pic, int hp,
     e->sight_range = sight_range;
     e->strength = strength;
     e->speed = speed;
+    e->potential = 0;
     e->xp = xp;
     e->name = name;
     e->node = list_add_tail(floor_enemy_list, e);
@@ -159,13 +160,18 @@ void enemy_clear()
     enemy_list->tail = 0;
 }
 
-void enemy_turn_driver(WINDOW * win, int y, int x, int subtick)
+void enemy_turn_driver(WINDOW * win, int y, int x)
 {
+    int player_speed;
     enemy_t *e;
-    node_t *l = enemy_list->head;
+    node_t *l;
+    player_speed = get_player_obj()->speed;
+    l = enemy_list->head;
     while (l) {
         e = (enemy_t*)l->data;
-        if (e->speed > subtick) {
+        e->potential += e->speed;
+        while (e->potential >= player_speed) {
+            e->potential -= player_speed;
             enemy_take_turn(e, win, y, x);
         }
         l = l->next;

--- a/src/logic/enemy.h
+++ b/src/logic/enemy.h
@@ -9,6 +9,7 @@ typedef struct enemy {
     int y;
     int x;
     int sight_range;
+    int speed;
     int strength;
     int xp;
     char *name;
@@ -16,13 +17,13 @@ typedef struct enemy {
 } enemy_t;
 
 enemy_t *enemy_add(list_t * floor_enemy_list, int type, int pic, int hp,
-                   int y, int x, int sight_range, int strength, int xp,
-                   char *name);
+                   int y, int x, int sight_range, int strength, 
+                   int speed, int xp, char *name);
 enemy_t *enemy_at(int y, int x);
 void enemy_set(list_t * list);
 void enemy_hurt(enemy_t * e, int d);
 void enemy_draw(WINDOW * win, int y, int x);
 void enemy_clear(void);
-void enemy_turn_driver(WINDOW * win, int y, int x);
+void enemy_turn_driver(WINDOW * win, int y, int x, int subtick);
 list_t *get_enemy_list(void);
 #endif

--- a/src/logic/enemy.h
+++ b/src/logic/enemy.h
@@ -10,6 +10,7 @@ typedef struct enemy {
     int x;
     int sight_range;
     int speed;
+    int potential;
     int strength;
     int xp;
     char *name;
@@ -24,6 +25,6 @@ void enemy_set(list_t * list);
 void enemy_hurt(enemy_t * e, int d);
 void enemy_draw(WINDOW * win, int y, int x);
 void enemy_clear(void);
-void enemy_turn_driver(WINDOW * win, int y, int x, int subtick);
+void enemy_turn_driver(WINDOW * win, int y, int x);
 list_t *get_enemy_list(void);
 #endif

--- a/src/logic/enemy_rulebook.c
+++ b/src/logic/enemy_rulebook.c
@@ -25,6 +25,7 @@ void generate_enemies()
     rulebook[book_length].base_hp = 30;
     rulebook[book_length].base_sight_range = 10;
     rulebook[book_length].base_exp = 10;
+    rulebook[book_length].base_speed = 8;
     rulebook[book_length].base_strength = 5;
     book_length++;
 
@@ -34,6 +35,7 @@ void generate_enemies()
     rulebook[book_length].base_hp = 50;
     rulebook[book_length].base_sight_range = 15;
     rulebook[book_length].base_strength = 10;
+    rulebook[book_length].base_speed = 5;
     rulebook[book_length].base_exp = 15;
     book_length++;
 
@@ -43,6 +45,7 @@ void generate_enemies()
     rulebook[book_length].base_hp = 50;
     rulebook[book_length].base_sight_range = 15;
     rulebook[book_length].base_strength = 15;
+    rulebook[book_length].base_speed = 6;
     rulebook[book_length].base_exp = 15;
     book_length++;
 
@@ -52,6 +55,7 @@ void generate_enemies()
     rulebook[book_length].base_hp = 50;
     rulebook[book_length].base_sight_range = 15;
     rulebook[book_length].base_strength = 15;
+    rulebook[book_length].base_speed = 5;
     rulebook[book_length].base_exp = 15;
     snek = book_length;
     book_length++;
@@ -62,6 +66,7 @@ void generate_enemies()
     rulebook[book_length].base_hp = 75;
     rulebook[book_length].base_sight_range = 15;
     rulebook[book_length].base_strength = 7;
+    rulebook[book_length].base_speed = 5;
     rulebook[book_length].base_exp = 20;
     book_length++;
 
@@ -71,6 +76,7 @@ void generate_enemies()
     rulebook[book_length].base_hp = 75;
     rulebook[book_length].base_sight_range = 15;
     rulebook[book_length].base_strength = 15;
+    rulebook[book_length].base_speed = 5;
     rulebook[book_length].base_exp = 20;
     book_length++;
 
@@ -80,6 +86,7 @@ void generate_enemies()
     rulebook[book_length].base_hp = 50;
     rulebook[book_length].base_sight_range = 15;
     rulebook[book_length].base_strength = 30;
+    rulebook[book_length].base_speed = 5;
     rulebook[book_length].base_exp = 30;
     book_length++;
 
@@ -89,6 +96,7 @@ void generate_enemies()
     rulebook[book_length].base_hp = 75;
     rulebook[book_length].base_sight_range = 15;
     rulebook[book_length].base_strength = 30;
+    rulebook[book_length].base_speed = 5;
     rulebook[book_length].base_exp = 35;
     book_length++;
 
@@ -98,6 +106,7 @@ void generate_enemies()
     rulebook[book_length].base_hp = 100;
     rulebook[book_length].base_sight_range = 20;
     rulebook[book_length].base_strength = 30;
+    rulebook[book_length].base_speed = 5;
     rulebook[book_length].base_exp = 40;
     book_length++;
 
@@ -107,6 +116,7 @@ void generate_enemies()
     rulebook[book_length].base_hp = 60;
     rulebook[book_length].base_sight_range = 20;
     rulebook[book_length].base_strength = 50;
+    rulebook[book_length].base_speed = 5;
     rulebook[book_length].base_exp = 40;
     book_length++;
 
@@ -116,6 +126,7 @@ void generate_enemies()
     rulebook[book_length].base_hp = 1;
     rulebook[book_length].base_sight_range = 0;
     rulebook[book_length].base_strength = 50;
+    rulebook[book_length].base_speed = 5;
     rulebook[book_length].base_exp = 50;
     fake_hag = book_length;
     book_length++;
@@ -126,6 +137,7 @@ void generate_enemies()
     rulebook[book_length].base_hp = 30;
     rulebook[book_length].base_sight_range = 0;
     rulebook[book_length].base_strength = 60;
+    rulebook[book_length].base_speed = 5;
     rulebook[book_length].base_exp = 70;
     hag = book_length;
     book_length++;
@@ -202,8 +214,8 @@ void enemy_take_turn(enemy_t * e, WINDOW * win, int y, int x)
                 add_action("The old hag summons a dangerous snek!");
                 n = enemy_add(0, snek, en.pic, en.base_hp, e->y,
                               e->x + xdiff, en.base_sight_range,
-                              en.base_strength, en.base_exp,
-                              "dangerous snek");
+                              en.base_strength, en.base_speed,
+                              en.base_exp, "dangerous snek");
                 map_line(e->y, e->x, n->y, n->x);
             }
         }

--- a/src/logic/enemy_rulebook.c
+++ b/src/logic/enemy_rulebook.c
@@ -25,7 +25,7 @@ void generate_enemies()
     rulebook[book_length].base_hp = 30;
     rulebook[book_length].base_sight_range = 10;
     rulebook[book_length].base_exp = 10;
-    rulebook[book_length].base_speed = 8;
+    rulebook[book_length].base_speed = 5;
     rulebook[book_length].base_strength = 5;
     book_length++;
 
@@ -35,7 +35,7 @@ void generate_enemies()
     rulebook[book_length].base_hp = 50;
     rulebook[book_length].base_sight_range = 15;
     rulebook[book_length].base_strength = 10;
-    rulebook[book_length].base_speed = 1;
+    rulebook[book_length].base_speed = 5;
     rulebook[book_length].base_exp = 15;
     book_length++;
 

--- a/src/logic/enemy_rulebook.c
+++ b/src/logic/enemy_rulebook.c
@@ -35,7 +35,7 @@ void generate_enemies()
     rulebook[book_length].base_hp = 50;
     rulebook[book_length].base_sight_range = 15;
     rulebook[book_length].base_strength = 10;
-    rulebook[book_length].base_speed = 5;
+    rulebook[book_length].base_speed = 1;
     rulebook[book_length].base_exp = 15;
     book_length++;
 

--- a/src/logic/enemy_rulebook.h
+++ b/src/logic/enemy_rulebook.h
@@ -8,6 +8,7 @@ typedef struct enemy_template {
     int base_hp;
     int base_sight_range;
     int base_strength;
+    int base_speed;
     int base_exp;
 } enemy_template_t;
 void generate_enemies(void);

--- a/src/logic/player.c
+++ b/src/logic/player.c
@@ -11,6 +11,7 @@ static player_t player = {
     10,  /* strength */
     10,  /* dexterity */
     10,  /* intelligence */
+    5,   /* speed */
     0,   /* current_exp */
     112, /* max_exp */
     1,   /* current_level */

--- a/src/logic/player.h
+++ b/src/logic/player.h
@@ -8,6 +8,7 @@ typedef struct player {
     int strength;
     int dexterity;
     int intelligence;
+    int speed;
     int current_exp;
     int max_exp;
     int current_level;

--- a/src/ui/key.c
+++ b/src/ui/key.c
@@ -27,7 +27,6 @@ void key_setup()
 void key_add_stair(int dir, int pic)
 {
     key_item_t *e;
-    system("echo crap > hello");
     key_setup();
     e = (key_item_t*)malloc(sizeof(*e));
     if (dir == 0) {
@@ -38,7 +37,6 @@ void key_add_stair(int dir, int pic)
     sprintf((e->extra_info), "goto floor %d", floor_get() - 1);
 
     e->pic = pic;
-    system("echo crap > hello");
     e->node = list_add_tail(key_list, e);
 }
 

--- a/src/util/rng.c
+++ b/src/util/rng.c
@@ -4,7 +4,7 @@
 int rng_rand(int max)
 {
     int limit = RAND_MAX - (RAND_MAX % (max + 1)), r;
-    while ((r = rand()) >= limit) ;
+    while ((r = rand()) >= limit);
     return r % (max + 1);
 }
 

--- a/src/world/floor.c
+++ b/src/world/floor.c
@@ -93,6 +93,7 @@ static void floor_init(void)
                                       en.base_sight_range,
                                       en.base_strength +
                                       rand() % (floor_get() + 1),
+                                      en.base_speed,
                                       en.base_exp, en.name);
                         }
                         if (rand() % (8000 + 1) <= 2 * (floor_get() + 5)) {
@@ -127,8 +128,8 @@ static void floor_init(void)
             type = enemy_index_hag();
             en = get_rulebook()[type];
             enemy_add(enemies, type, en.pic, en.base_hp, down_y, down_x,
-                      en.base_sight_range, en.base_strength, en.base_exp,
-                      en.name);
+                      en.base_sight_range, en.base_strength, en.base_speed,
+                      en.base_exp, en.name);
             xpos = down_x - 10;
             ypos = down_y - 10;
             for (i = 0; i < ylen; i++) {


### PR DESCRIPTION
Adds a new stat, **speed**.
**speed** determines how frequently an entity may act. An enemy with a speed lower than the player's will occasionally not move during a turn (deterministically, not probabilistically). An enemy with a speed greater than the players will occasionally move more than once during a turn (again, deterministically). 

This stat opens up some interesting possibilities. Enemies may become "frozen" by setting their **speed** to 0. Players may gain a substantial DPS buff with a slight increase to **speed**. Different weapons may impact **speed** differently, adding a trade-off between a weaker weapon that allows for moving and attacking more often, or a stronger weapon that leaves you more vulnerable to damage.  