### PR TITLE
Enemy stats

### DIFF
--- a/src/core/main.c
+++ b/src/core/main.c
@@ -234,6 +234,8 @@ int main(int argc, char **argv)
                     add_action(msg);
                 } else {
                     int damage = player_damage_dealt();
+                    damage *= 10 - *(&at->stat_str + item_stat() - 1);
+                    damage /= 5;
                     if (rand() % 20000 < player->luck) {
                         char msg[80];
                         sprintf(msg,

--- a/src/logic/enemy.c
+++ b/src/logic/enemy.c
@@ -16,6 +16,7 @@ void enemy_set(list_t * list)
 
 enemy_t *enemy_add(list_t * floor_enemy_list, int type, int pic, int hp,
                    int y, int x, int sight_range, int strength,
+                   int stat_str, int stat_dex, int stat_int,
                    int speed, int xp, char *name)
 {
     enemy_t *e;
@@ -37,6 +38,9 @@ enemy_t *enemy_add(list_t * floor_enemy_list, int type, int pic, int hp,
     e->speed = speed;
     e->potential = 0;
     e->xp = xp;
+    e->stat_int = stat_int;
+    e->stat_dex = stat_dex;
+    e->stat_str = stat_str;
     e->name = name;
     e->node = list_add_tail(floor_enemy_list, e);
     return e;
@@ -93,7 +97,8 @@ void enemy_hurt(enemy_t * e, int d)
                     en = get_rulebook()[enemy_index_fake_hag()];
                     enemy_add(0, enemy_index_fake_hag(), en.pic,
                               en.base_hp, ny, nx, en.base_sight_range,
-                              en.base_strength, en.base_speed,
+                              en.base_strength, en.stat_str, en.stat_dex,
+                              en.stat_int, en.base_speed,
                               en.base_exp, "Fake");
                     nx += (rand() % 2 * 2 - 1) * ((rand() % 4) + 5);
                     ny += (rand() % 2 * 2 - 1) * ((rand() % 4) + 5);

--- a/src/logic/enemy.h
+++ b/src/logic/enemy.h
@@ -12,6 +12,9 @@ typedef struct enemy {
     int speed;
     int potential;
     int strength;
+    int stat_str;
+    int stat_int;
+    int stat_dex;
     int xp;
     char *name;
     node_t *node;
@@ -19,6 +22,7 @@ typedef struct enemy {
 
 enemy_t *enemy_add(list_t * floor_enemy_list, int type, int pic, int hp,
                    int y, int x, int sight_range, int strength,
+                   int stat_str, int stat_dex, int stat_int,
                    int speed, int xp, char *name);
 enemy_t *enemy_at(int y, int x);
 void enemy_set(list_t * list);

--- a/src/logic/enemy.h
+++ b/src/logic/enemy.h
@@ -13,8 +13,8 @@ typedef struct enemy {
     int potential;
     int strength;
     int stat_str;
-    int stat_int;
     int stat_dex;
+    int stat_int;
     int xp;
     char *name;
     node_t *node;

--- a/src/logic/enemy_rulebook.c
+++ b/src/logic/enemy_rulebook.c
@@ -27,6 +27,9 @@ void generate_enemies()
     rulebook[book_length].base_exp = 10;
     rulebook[book_length].base_speed = 5;
     rulebook[book_length].base_strength = 5;
+    rulebook[book_length].stat_int = 5;
+    rulebook[book_length].stat_dex = 5;
+    rulebook[book_length].stat_str = 5;
     book_length++;
 
     /* kobold */
@@ -37,6 +40,9 @@ void generate_enemies()
     rulebook[book_length].base_strength = 10;
     rulebook[book_length].base_speed = 5;
     rulebook[book_length].base_exp = 15;
+    rulebook[book_length].stat_int = 0;
+    rulebook[book_length].stat_dex = 5;
+    rulebook[book_length].stat_str = 5;
     book_length++;
 
     /* goblin */
@@ -47,6 +53,9 @@ void generate_enemies()
     rulebook[book_length].base_strength = 15;
     rulebook[book_length].base_speed = 6;
     rulebook[book_length].base_exp = 15;
+    rulebook[book_length].stat_int = 5;
+    rulebook[book_length].stat_dex = 0;
+    rulebook[book_length].stat_str = 5;
     book_length++;
 
     /* snake */
@@ -57,6 +66,9 @@ void generate_enemies()
     rulebook[book_length].base_strength = 15;
     rulebook[book_length].base_speed = 5;
     rulebook[book_length].base_exp = 15;
+    rulebook[book_length].stat_int = 5;
+    rulebook[book_length].stat_dex = 5;
+    rulebook[book_length].stat_str = 0;
     snek = book_length;
     book_length++;
 
@@ -68,6 +80,9 @@ void generate_enemies()
     rulebook[book_length].base_strength = 7;
     rulebook[book_length].base_speed = 5;
     rulebook[book_length].base_exp = 20;
+    rulebook[book_length].stat_int = 5;
+    rulebook[book_length].stat_dex = 5;
+    rulebook[book_length].stat_str = 10;
     book_length++;
 
     /* orc */
@@ -78,6 +93,9 @@ void generate_enemies()
     rulebook[book_length].base_strength = 15;
     rulebook[book_length].base_speed = 5;
     rulebook[book_length].base_exp = 20;
+    rulebook[book_length].stat_int = 5;
+    rulebook[book_length].stat_dex = 5;
+    rulebook[book_length].stat_str = 5;
     book_length++;
 
     /* wolf */
@@ -88,6 +106,9 @@ void generate_enemies()
     rulebook[book_length].base_strength = 30;
     rulebook[book_length].base_speed = 5;
     rulebook[book_length].base_exp = 30;
+    rulebook[book_length].stat_int = 5;
+    rulebook[book_length].stat_dex = 5;
+    rulebook[book_length].stat_str = 5;
     book_length++;
 
     /* imp */
@@ -98,6 +119,9 @@ void generate_enemies()
     rulebook[book_length].base_strength = 30;
     rulebook[book_length].base_speed = 5;
     rulebook[book_length].base_exp = 35;
+    rulebook[book_length].stat_int = 10;
+    rulebook[book_length].stat_dex = 5;
+    rulebook[book_length].stat_str = 5;
     book_length++;
 
     /* griffin */
@@ -108,6 +132,9 @@ void generate_enemies()
     rulebook[book_length].base_strength = 30;
     rulebook[book_length].base_speed = 5;
     rulebook[book_length].base_exp = 40;
+    rulebook[book_length].stat_int = 5;
+    rulebook[book_length].stat_dex = 5;
+    rulebook[book_length].stat_str = 5;
     book_length++;
 
     /* grue */
@@ -118,6 +145,9 @@ void generate_enemies()
     rulebook[book_length].base_strength = 50;
     rulebook[book_length].base_speed = 5;
     rulebook[book_length].base_exp = 40;
+    rulebook[book_length].stat_int = 5;
+    rulebook[book_length].stat_dex = 10;
+    rulebook[book_length].stat_str = 5;
     book_length++;
 
     /* fake hag */
@@ -128,6 +158,9 @@ void generate_enemies()
     rulebook[book_length].base_strength = 50;
     rulebook[book_length].base_speed = 5;
     rulebook[book_length].base_exp = 50;
+    rulebook[book_length].stat_int = 5;
+    rulebook[book_length].stat_dex = 5;
+    rulebook[book_length].stat_str = 5;
     fake_hag = book_length;
     book_length++;
 
@@ -139,6 +172,9 @@ void generate_enemies()
     rulebook[book_length].base_strength = 60;
     rulebook[book_length].base_speed = 5;
     rulebook[book_length].base_exp = 70;
+    rulebook[book_length].stat_int = 5;
+    rulebook[book_length].stat_dex = 5;
+    rulebook[book_length].stat_str = 5;
     hag = book_length;
     book_length++;
 }
@@ -214,7 +250,8 @@ void enemy_take_turn(enemy_t * e, WINDOW * win, int y, int x)
                 add_action("The old hag summons a dangerous snek!");
                 n = enemy_add(0, snek, en.pic, en.base_hp, e->y,
                               e->x + xdiff, en.base_sight_range,
-                              en.base_strength, en.base_speed,
+                              en.base_strength, en.stat_str,
+                              en.stat_dex, en.stat_int, en.base_speed,
                               en.base_exp, "dangerous snek");
                 map_line(e->y, e->x, n->y, n->x);
             }

--- a/src/logic/enemy_rulebook.h
+++ b/src/logic/enemy_rulebook.h
@@ -10,6 +10,9 @@ typedef struct enemy_template {
     int base_strength;
     int base_speed;
     int base_exp;
+    int stat_int;
+    int stat_dex;
+    int stat_str;
 } enemy_template_t;
 void generate_enemies(void);
 enemy_template_t *get_rulebook(void);

--- a/src/logic/player.h
+++ b/src/logic/player.h
@@ -1,5 +1,7 @@
 #ifndef PLAYER_H
 #define PLAYER_H
+#include "enemy.h"
+
 typedef struct player {
     int current_hp;
     int max_hp;

--- a/src/world/floor.c
+++ b/src/world/floor.c
@@ -146,7 +146,7 @@ static void floor_init(void)
             type = enemy_index_hag();
             en = get_rulebook()[type];
             enemy_add(enemies, type, en.pic, en.base_hp, down_y, down_x,
-                      en.base_sight_range, en.base_strength, 
+                      en.base_sight_range, en.base_strength,
                       en.stat_str, en.stat_dex, en.stat_int,
                       en.base_speed,
                       en.base_exp, en.name);

--- a/src/world/floor.c
+++ b/src/world/floor.c
@@ -94,6 +94,7 @@ static void floor_init(void)
                                       en.base_sight_range,
                                       en.base_strength +
                                       rand() % (floor_get() + 1),
+                                      en.stat_str, en.stat_dex, en.stat_int,
                                       en.base_speed,
                                       en.base_exp, en.name);
                         }
@@ -145,7 +146,9 @@ static void floor_init(void)
             type = enemy_index_hag();
             en = get_rulebook()[type];
             enemy_add(enemies, type, en.pic, en.base_hp, down_y, down_x,
-                      en.base_sight_range, en.base_strength, en.base_speed,
+                      en.base_sight_range, en.base_strength, 
+                      en.stat_str, en.stat_dex, en.stat_int,
+                      en.base_speed,
                       en.base_exp, en.name);
             xpos = down_x - 10;
             ypos = down_y - 10;


### PR DESCRIPTION
This change adds the str, int, and dex defence stats to each monster. Each monster has these stats between 0 and 10, and each stat point away from 5 causes a 20% change in damage, so having a 10 in a stat causes a 100% reduction in damage from that type of damage, while a 0 in a state causes a 100% increase in damage.

For example, a kobold has 5 in dex and str, so dex and str weapons damage kobolds normally. But kobolds have a 0 in int, so an int weapon would do double damage against them.

The intent ~is to provide players with a sense of pride and accomplishment for unlocking different heroes~ is to have the weapon types be more meaningfully distinct.