### PR TITLE
Player miss on zero damage

### DIFF
--- a/src/core/main.c
+++ b/src/core/main.c
@@ -258,6 +258,7 @@ int main(int argc, char **argv)
         if (map_get(yn, xn) == '.' || map_get(yn, xn) == '<'
             || map_get(yn, xn) == '>') {
             if (at) {
+                int damage;
                 if (fight_pre == 1) {
                     repeat_act = ch;
                     fight_pre = 2;
@@ -266,13 +267,13 @@ int main(int argc, char **argv)
                     run_pre = 0;
                     repeat_act = 0;
                 }
-                if (rand() % player->luck == 0) {
+                damage = player_damage_dealt();
+                if ((rand() % player->luck == 0) || (damage == 0)) {
                     char msg[80];
                     sprintf(msg, "You swing at the %s, but miss.",
                             get_rulebook()[at->type].name);
                     add_action(msg);
                 } else {
-                    int damage = player_damage_dealt();
                     damage *= 10 - *(&at->stat_str + item_stat() - 1);
                     damage /= 5;
                     if (rand() % 20000 < player->luck) {

--- a/src/core/main.c
+++ b/src/core/main.c
@@ -19,11 +19,15 @@
 #include "enemy.h"
 #include "gui.h"
 #include "key.h"
+#include "main.h"
 
 #define W 60
 #define H 13
 
 int tick = 0;
+
+
+
 
 int main(int argc, char **argv)
 {
@@ -258,7 +262,6 @@ int main(int argc, char **argv)
         if (map_get(yn, xn) == '.' || map_get(yn, xn) == '<'
             || map_get(yn, xn) == '>') {
             if (at) {
-                int damage;
                 if (fight_pre == 1) {
                     repeat_act = ch;
                     fight_pre = 2;
@@ -267,30 +270,7 @@ int main(int argc, char **argv)
                     run_pre = 0;
                     repeat_act = 0;
                 }
-                damage = player_damage_dealt();
-                if ((rand() % player->luck == 0) || (damage == 0)) {
-                    char msg[80];
-                    sprintf(msg, "You swing at the %s, but miss.",
-                            get_rulebook()[at->type].name);
-                    add_action(msg);
-                } else {
-                    damage *= 10 - *(&at->stat_str + item_stat() - 1);
-                    damage /= 5;
-                    if (rand() % 20000 < player->luck) {
-                        char msg[80];
-                        sprintf(msg,
-                                "You land a critical blow against the %s for %d life.",
-                                get_rulebook()[at->type].name, damage * 2);
-                        add_action(msg);
-                        enemy_hurt(at, damage * 2);
-                    } else {
-                        char msg[80];
-                        sprintf(msg, "You hurt the %s for %d life.",
-                                get_rulebook()[at->type].name, damage);
-                        add_action(msg);
-                        enemy_hurt(at, damage);
-                    }
-                }
+                player_attacks(player, at);
             } else {
                 if (fight_pre == 2) {
                     repeat_act = 0;
@@ -318,4 +298,32 @@ int main(int argc, char **argv)
 
     endwin();
     return 0;
+}
+void player_attacks(player_t *player, enemy_t *at)
+{
+    int damage;
+    damage = player_damage_dealt();
+    if ((rand() % player->luck == 0) || (damage == 0)) {
+        char msg[80];
+        sprintf(msg, "You swing at the %s, but miss.",
+                get_rulebook()[at->type].name);
+        add_action(msg);
+    } else {
+        damage *= 10 - *(&at->stat_str + item_stat() - 1);
+        damage /= 5;
+        if (rand() % 20000 < player->luck) {
+            char msg[80];
+            sprintf(msg,
+                    "You land a critical blow against the %s for %d life.",
+                    get_rulebook()[at->type].name, damage * 2);
+            add_action(msg);
+            enemy_hurt(at, damage * 2);
+        } else {
+            char msg[80];
+            sprintf(msg, "You hurt the %s for %d life.",
+                    get_rulebook()[at->type].name, damage);
+            add_action(msg);
+            enemy_hurt(at, damage);
+        }
+    }
 }

--- a/src/core/main.h
+++ b/src/core/main.h
@@ -1,3 +1,4 @@
 #ifndef MAIN_H
 extern int tick;
+void player_attacks(player_t *player, enemy_t *at);
 #endif


### PR DESCRIPTION
Changed the attack miss check to look at the base damage the player will do, damage_dealt(), in addition to the luck check. Actual damage a player would deal normally or on critical is a multiple of this base damage, so this grabs both normal and critical zero damage hits. 

So now only hits that do damage hit per  #123 

There's one commit that adds this, and a second commit that moves the player attack hit/miss and damage calculation out to a separate function. Bit cleaner and attack logic is will only get more complicated as time goes on. 

Note this doesn't effect hits by enemies that do zero damage. The attack/damage/miss logic for them is separate (logic/enemy_rulebook/enemy_take_turn).  So "The foo hurts you for 0 life." still happen, though they can't crit. 

Both player and enemy should be using the same code as much as possible, so figure let this stuff come from that. 

If we want enemies to start missing sooner, can add the miss check to them. 
