### PR TITLE
Add compiler flag for usleep

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,8 @@ OBJECTS  = $(addprefix $(OBJDIR), $(notdir $(SOURCES:.c=.o)))
 CC       = gcc 
 LINKS    =-lncurses -lpanel
 CC_FLAGS =-g -Wall -std=c89 -pedantic -Wextra -Werror \
-		  -Wmissing-prototypes -Wstrict-prototypes $(INCLUDE)
+		  -Wmissing-prototypes -Wstrict-prototypes $(INCLUDE) \
+		  -D__NEED_USLEEP__
 ID       = uncrustify
 ID_FLAGS =-c uncrustify.cfg
 

--- a/src/core/demo.c
+++ b/src/core/demo.c
@@ -12,7 +12,7 @@ static FILE* write_to = 0;
 
 static int demo_speed = 300;
 
-#if __NEED_USLEEP__
+#ifdef __NEED_USLEEP__
 void usleep(long); /* needed because headers are big sad */
 #endif
 


### PR DESCRIPTION
Usleep being defined is... complicated, so how about we just move it out entirely, and let the build system deal with it? This will resolve #161.